### PR TITLE
Sending results to the collection server

### DIFF
--- a/kitchensink-app/css/app.css
+++ b/kitchensink-app/css/app.css
@@ -165,7 +165,7 @@ x-appbar #header-reload:before {
 }
 
 #body-settings p {
-	padding: 5px 5% 0 5%;
+	padding: 5px 5% 0;
 }
 
 #body-settings #settings-done {

--- a/kitchensink-app/css/app.css
+++ b/kitchensink-app/css/app.css
@@ -165,7 +165,7 @@ x-appbar #header-reload:before {
 }
 
 #body-settings p {
-	padding: 5px 5%;
+	padding: 5px 5% 0 5%;
 }
 
 #body-settings #settings-done {

--- a/kitchensink-app/index.html
+++ b/kitchensink-app/index.html
@@ -12,12 +12,12 @@
 <body>
   <section id="body-settings" class="hidden dark">
     <p>
-      <input type="checkbox" id="certifiedVisible" name="certifiedVisible"/>
-      <label for="certifiedVisible">Show certified</label>
+      <input type="checkbox" id="certified-visible" name="certified-visible"/>
+      <label for="certified-visible">Show certified</label>
     </p>
     <p>
-      <input type="checkbox" id="sendResults" name="sendResults"/>
-      <label for="sendResults">Send test results to Mozilla</label>
+      <input type="checkbox" id="send-results" name="send-results"/>
+      <label for="send-results">Send test results to Mozilla</label>
     </p>
     <button id="settings-done">Done</button>
   </section>

--- a/kitchensink-app/index.html
+++ b/kitchensink-app/index.html
@@ -11,7 +11,14 @@
 </head>
 <body>
   <section id="body-settings" class="hidden dark">
-    <p>Show certified <input type="checkbox" id="certifiedVisible"/></p>
+    <p>
+      <input type="checkbox" id="certifiedVisible" name="certifiedVisible"/>
+      <label for="certifiedVisible">Show certified</label>
+    </p>
+    <p>
+      <input type="checkbox" id="sendResults" name="sendResults"/>
+      <label for="sendResults">Send test results to Mozilla</label>
+    </p>
     <button id="settings-done">Done</button>
   </section>
   <section id="body-content">

--- a/kitchensink-app/js/apis/battery.js
+++ b/kitchensink-app/js/apis/battery.js
@@ -34,11 +34,11 @@ define(function(require) {
       function(callback) {
         var dischargingTime = navigator.battery.dischargingTime;
         var isValid = (dischargingTime === Infinity || parseInt(dischargingTime, 10));
-        callback(!!isValid, 'battery', 'Battery Status API', 'check discharging time value');
+        callback(!!isValid, 'Battery discharging time', 'check discharging time value');
       },
       function(callback) {
         var level = navigator.battery.level * 100;
-        callback(!!parseInt(level, 10), 'battery', 'Battery Status API', 'check level value', level);
+        callback(!!parseInt(level, 10), 'Battery level value', 'check level value' + level);
       }
     ]
   });

--- a/kitchensink-app/js/app.js
+++ b/kitchensink-app/js/app.js
@@ -4,6 +4,7 @@
 define(function(require) {
 
   require('string'); // modifies String prototype
+  var settings = require('settings');
   var $ = require('elements');
   require('elements/events');       // used for .on()
   require('elements/attributes');   // .html() in utils.js
@@ -12,6 +13,8 @@ define(function(require) {
   var renderCertified = require('./ui').renderCertified;
   var apis = require('./apis/index');
   var log = require('logger');
+
+
 
   $('#header-reload').on('click', function() { 
     window.location.reload(); 
@@ -27,15 +30,50 @@ define(function(require) {
       $('#body-settings').addClass('hidden');
   });
 
+  // This object will collect data about tests
+  var results = {};
+
+  // store number of collected APIs to find out if all are collected
+  var collectedApi = 0;
+
+  var collection = require('./collection');
+  // try to send collected results if sendResult setting switched
+  settings.on('sendResults', function() {
+    collection.sendResults(results);
+  });
+
+  /**
+   * Callback which stores results of the API tests.
+   *
+   * params:
+   *    currentResult: results of the API tests
+   *    collectedResult: object containing the preparation test result
+   */ 
+  function storeResult(currentResult, collectedResult) {
+    // count the API
+    collectedApi++;
+    // get the API's id from the result
+    apiId = currentResult.api;
+    delete currentResult.api;
+    // store result
+    collectedResult.tests = currentResult;
+    results[apiId] = collectedResult; 
+
+    if (collectedApi == apis.length) {
+      collection.sendResults(results);
+    }
+  }
+
   for (var id in apis) {
+    var result = {};
     var api = apis[id];
     // render <dt> and <dd> inside <dl id="apis">
     // assign action if provided
     api.render($('#apis'));
     // check if DOM is prepared
-    api.testPreparation();
-    // run tests if provided
-    api.runTests();
+    result.preparation = api.testPreparation();
+    // run tests if provided and send results to server
+    api.runTests(storeResult, result);
   }
 
   renderCertified();

--- a/kitchensink-app/js/app.js
+++ b/kitchensink-app/js/app.js
@@ -14,8 +14,6 @@ define(function(require) {
   var apis = require('./apis/index');
   var log = require('logger');
 
-
-
   $('#header-reload').on('click', function() { 
     window.location.reload(); 
   });
@@ -59,7 +57,7 @@ define(function(require) {
     collectedResult.tests = currentResult;
     results[apiId] = collectedResult; 
 
-    if (collectedApi == apis.length) {
+    if (collectedApi === apis.length) {
       collection.sendResults(results);
     }
   }

--- a/kitchensink-app/js/collection.js
+++ b/kitchensink-app/js/collection.js
@@ -1,0 +1,233 @@
+define(function(require) {
+  var settings = require('settings');
+  var prime = require('prime');
+  var Emitter = require('prime/emitter');
+
+  /**
+   * Helper class to provide CORS requests
+   * TODO: make it more generic and move to lib directory
+   */
+  var CORSRequest = prime({
+    inherits: Emitter,
+
+    constructor: function(method, url, data, callback) {
+      var self = this;
+
+      this.request = new XMLHttpRequest({
+        mozSystem: true,
+        mozAnon: true
+      });
+    
+      this.method = method.toUpperCase();
+
+      if (data) {
+        this.data = JSON.stringify(data);
+      } else {
+        // empty string is not valid for tastypie
+        this.data = '{}';
+      }
+
+      this.request.open(this.method, url + '?format=json');
+      this.request.setRequestHeader('Content-type', 'application/json');
+      this.request.setRequestHeader('X-PINGOTHER', 'pingpong');
+
+      this.request.onload = function() {
+        if (self.request.status === 404 ||
+            self.request.status === 500) {
+          self.emit('error', this.request.status);
+          return;
+        }
+        self.emit('success', this.responseText); 
+      };
+
+      if (callback) {
+        this.send(callback);
+      }
+    },
+
+    send: function(callback) {
+      this.on('success', callback);
+      this.request.send(this.data);
+    }
+  });
+
+  var Collection = prime({
+    inherits: Emitter,
+    collectionServer: settings.get('collectionServer'),
+    apiPrefix: '/api/v1',
+
+    constructor: function() {
+      var self = this;
+      this.on('ready', function() {
+        self.ready = true;
+      });
+
+      // this array will be empty after all data retrieved
+      var allCallbacks = ['phone', 'app_version'];
+
+      if ('lastCollectedData' in localStorage) {
+        this.lastCollectedData = localStorage.lastCollectedData;
+      }
+
+      this.setPhoneResourceUri(function() {
+        delete allCallbacks[allCallbacks.indexOf('phone')];
+        if (allCallbacks.length === 0) {
+          this.emit('ready');
+        }
+      });
+
+      // get app_version
+      var request = window.navigator.mozApps.getSelf();
+      request.onsuccess = function() {
+        delete allCallbacks[allCallbacks.indexOf('app_version')];
+        if (request.result) {
+          self.appVersion = request.result.manifest.version;
+        } else {
+          self.appVersion = 0;
+        }
+        if (allCallbacks.length === 0) {
+          this.emit('ready');
+        }
+      };
+    },
+
+    /**
+     * returns app id stored in localStorage or retrieves one from
+     * collection server
+     */
+    getPhoneResourceUri: function(callback) {
+      var self = this;
+      if (settings.get('phoneResourceUri')) {
+        callback(settings.get('phoneResourceUri'));
+        return;
+      }
+      if (!settings.get('sendResults')) {
+        callback(undefined);
+        return;
+      }
+      // retrieve phoneResourceUri from collection server
+      new CORSRequest('post', this.collectionServer + this.apiPrefix + '/phone/', 
+          {}, function() {
+            var data = JSON.parse(this.responseText);
+            callback(data.resource_uri);
+          }
+      );
+    },
+
+    /**
+     * sets phoneResourceUri
+     */
+    setPhoneResourceUri: function(callback) {
+      var self = this;
+      this.getPhoneResourceUri(function(phoneResourceUri) {
+        if (phoneResourceUri) {
+          settings.set('phoneResourceUri', phoneResourceUri);
+        }
+        callback(phoneResourceUri);
+      });
+    },
+
+    /**
+     * prepares an object to be send to collection server
+     */
+    getFullData: function(currentResults) {
+      return {
+        test_result: JSON.stringify(currentResults),
+        device: settings.get('deviceModel'),
+        phone: settings.get('phoneResourceUri'),
+        app_version: this.appVersion,
+        user_agent: navigator.userAgent
+      };
+    },
+
+    /**
+     * send results to collection server
+     *
+     * param results: object containing all tests for supported APIs
+     */
+    sendResults: function(results) {
+      var self = this;
+      if (!settings.get('sendResults')) {
+        return;
+      }
+      if (settings.get('phoneResourceUri')) {
+        this._realSendResults(results);
+      } else {
+        this.setPhoneResourceUri(function() {
+          self._realSendResults(results);
+        });
+      }
+    },
+
+    _realSendResults: function(results) {
+      if (!settings.get('phoneResourceUri')) {
+        // it should never happened if called via sendResults
+        return;
+      }
+      var data = this.getFullData(results);
+      if (!diffLastResults(data)) {
+         return;
+       }
+      new CORSRequest('post', 
+          this.collectionServer + this.apiPrefix + '/result/', 
+          data, function() {
+            // TODO: add the success failure
+            localStorage.collectedData = JSON.stringify(data);
+          }
+      );
+    }
+  });
+
+  /** 
+   * Compare last results sent to current results
+   * returns null if no difference
+   */
+  function diffLastResults(currentData) {
+    if (!localStorage.collectedData) {
+      return true;
+    }
+    var collectedData = JSON.parse(localStorage.collectedData);
+    // compare currentData to collectedData 
+    // tests are stored as JSON string - thee will need to be parsed
+    // seoarately for each API
+   
+    if (collectedData.device !== currentData.device ||
+        collectedData.app_version !== currentData.app_version ||
+        collectedData.phone !== currentData.phone ||
+        collectedData.user_agent !== currentData.user_agent) {
+      return true;
+    } 
+
+    // compare test results
+    var collectedResults = JSON.parse(collectedData.test_result);
+    var currentResults = JSON.parse(currentData.test_result);
+    // check if number of APIs is the same
+    if (Object.keys(collectedData).length !== Object.keys(currentData).length) {
+      return true;
+    }
+    for (var apiId in currentResults) {
+      // check diff for each API
+      var current = currentResults[apiId];
+      if (!(apiId in collectedResults)) {
+        return true;
+      }
+      var collected = collectedResults[apiId];
+      if (collected.preparation !== current.preparation ||
+          Object.keys(current.tests).length !== Object.keys(collected.tests).length) {
+        return true;
+      }
+      for (var testName in current.tests) {
+        // check each test in API
+        if (!(testName in collected.tests) ||
+            current.tests[testName] !== collected.tests[testName]) {
+          return true;
+        }
+      }
+    }
+    // collectedData and currentData are the same
+    return false;
+  }
+
+
+  return new Collection();
+});

--- a/kitchensink-app/js/collection.js
+++ b/kitchensink-app/js/collection.js
@@ -71,7 +71,7 @@ define(function(require) {
 
       this.setPhoneResourceUri(function() {
         delete allCallbacks[allCallbacks.indexOf('phone')];
-        if (allCallbacks.length === 0) {
+        if (!allCallbacks) {
           this.emit('ready');
         }
       });

--- a/kitchensink-app/js/init.js
+++ b/kitchensink-app/js/init.js
@@ -13,6 +13,10 @@ require.config({
       { 
         name: 'elements',
         main: 'index'
+      },
+      { 
+        name: 'agent',
+        main: 'index'
       }
     ]
 });

--- a/kitchensink-app/js/lib/settings.js
+++ b/kitchensink-app/js/lib/settings.js
@@ -14,14 +14,14 @@ define(function(require) {
         // do not display certified apps by default
         value: false,
         // update setting from element
-        updateFrom: 'certifiedVisible',
+        updateFrom: 'certified-visible',
         isBoolean: true
       },
       sendResults: {
         // do not send results to the server by default
         value: false,
         // update setting from element
-        updateFrom: 'sendResults',
+        updateFrom: 'send-results',
         isBoolean: true
       },
       deviceModel: {

--- a/kitchensink-app/js/lib/settings.js
+++ b/kitchensink-app/js/lib/settings.js
@@ -16,6 +16,23 @@ define(function(require) {
         // update setting from element
         updateFrom: 'certifiedVisible',
         isBoolean: true
+      },
+      sendResults: {
+        // do not send results to the server by default
+        value: false,
+        // update setting from element
+        updateFrom: 'sendResults',
+        isBoolean: true
+      },
+      deviceModel: {
+        value: null
+        // TODO: find a way or decide if to get models from server
+      },
+      phoneResourceUri: {
+        value: null
+      },
+      collectionServer: {
+        value: 'http://127.0.0.1:8093'
       }
     },
 
@@ -23,7 +40,9 @@ define(function(require) {
       // update settings from localStorage
       var localSettings = JSON.parse(localStorage.settings || '{}');
       for (var key in localSettings) {
-        this.options[key].value = localSettings[key];
+        if (key in this.options) {
+          this.options[key].value = localSettings[key];
+        }
       } 
       this.store();
       this.updateElements();
@@ -52,31 +71,31 @@ define(function(require) {
      */
     updateElements: function() {
       var self = this;
+      function setCheckbox() {
+        self.set(this.key, this.checked());
+      }
+      function setInput() {
+        self.set(this.key, this.value);
+      }
       for (var key in this.options) {
         var item = this.options[key];
         if (item.updateFrom) {
           var element = $('#' + item.updateFrom);
+          element.key = key;
           if (item.isBoolean) {
             if (item.value) {
               element.check();
             } else {
               element.uncheck();
             }
-            // hook to change event
-            element.on('change', function() {
-              self.set(key, this.checked());
-            });
+            element.on('change', setCheckbox);
           } else {
             element.value = item.value;
-            // hook to change event
-            element.on('change', function() {
-              self.set(key, this.value);
-            });
+            element.on('change', setInput);
           }
         }
       }
-    },
-
+    }
   });
 
   return new Settings();

--- a/kitchensink-app/js/lib/string.js
+++ b/kitchensink-app/js/lib/string.js
@@ -1,13 +1,15 @@
-'use strict';
+(function () {
+  "use strict";
 
-// Do simple substitutions on any String object. (Monkeypatching FTW.)
-// Accepts either an array or an object of subsitutions.
-// If you supply an Array:
-//   `'Hello {0}.'.format(['world'])` will return: 'Hello world.'
-// If you supply an Object:
-//   `'Hello {world}.'.format({world: 'Earth'})` will return: 'Hello Earth.'
-String.prototype.format = function(substitutions) {
-  return this.replace(/\{([A-Za-z0-9]+)\}/g, function(match, key) {
-    return substitutions[key] !== undefined ? substitutions[key] : ''
-  })
-}
+  // Do simple substitutions on any String object. (Monkeypatching FTW.)
+  // Accepts either an array or an object of subsitutions.
+  // If you supply an Array:
+  //   `'Hello {0}.'.format(['world'])` will return: 'Hello world.'
+  // If you supply an Object:
+  //   `'Hello {world}.'.format({world: 'Earth'})` will return: 'Hello Earth.'
+  String.prototype.format = function(substitutions) {
+    return this.replace(/\{([A-Za-z0-9]+)\}/g, function(match, key) {
+      return substitutions[key] !== undefined ? substitutions[key] : '';
+    });
+  };
+})();

--- a/kitchensink-app/js/lib/utils.js
+++ b/kitchensink-app/js/lib/utils.js
@@ -7,5 +7,5 @@ define(function(require) {
 
   return {
     elements: elements
-  }
+  };
 });

--- a/kitchensink-app/js/ui.js
+++ b/kitchensink-app/js/ui.js
@@ -48,27 +48,6 @@ define(function(require) {
   } 
 
   /**
-   * sets the checkbox as the setting
-   */
-  function setCertifiedCheckBox() {
-    certifiedCheckBox = $('#certifiedVisible');
-    if (settings.get('certifiedVisible')) {
-      certifiedCheckBox.check();
-    } else {
-      certifiedCheckBox.uncheck();
-    }
-  }
-
-  /**
-   * sets the setting according to the checkbox state
-   */
-  function setCertified() {
-    // read checkbox
-    certifiedCheckBox = $('#certifiedVisible').checked();
-    settings.set('certifiedVisible', certifiedCheckBox);
-  }
-
-  /**
    * toggles certified dt's
    */
   function toggleCeritified() {
@@ -88,9 +67,6 @@ define(function(require) {
 
   // render certified on change of the setting
   settings.on('certifiedVisible', renderCertified);
-
-  // set the box as the setting
-  setCertifiedCheckBox();
 
   return {
     setStripes: setStripes,

--- a/kitchensink-app/js/ui.js
+++ b/kitchensink-app/js/ui.js
@@ -48,6 +48,27 @@ define(function(require) {
   } 
 
   /**
+   * sets the checkbox as the setting
+   */
+  function setCertifiedCheckBox() {
+    certifiedCheckBox = $('#certifiedVisible');
+    if (settings.get('certifiedVisible')) {
+      certifiedCheckBox.check();
+    } else {
+      certifiedCheckBox.uncheck();
+    }
+  }
+
+  /**
+   * sets the setting according to the checkbox state
+   */
+  function setCertified() {
+    // read checkbox
+    certifiedCheckBox = $('#certifiedVisible').checked();
+    settings.set('certifiedVisible', certifiedCheckBox);
+  }
+
+  /**
    * toggles certified dt's
    */
   function toggleCeritified() {
@@ -67,6 +88,9 @@ define(function(require) {
 
   // render certified on change of the setting
   settings.on('certifiedVisible', renderCertified);
+
+  // set the box as the setting
+  setCertifiedCheckBox();
 
   return {
     setStripes: setStripes,

--- a/kitchensink-app/manifest.webapp
+++ b/kitchensink-app/manifest.webapp
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.1",
+  "version": "0.3.0",
   "name": "KitchenSink",
   "description": "Tests and report APIs available on the device",
   "launch_path": "/index.html",
@@ -43,9 +43,6 @@
       "description": "Testing"
     },
     "tcp-socket": {
-      "description": "Testing"
-    },
-    "wifi-manage": {
       "description": "Testing"
     }
   }


### PR DESCRIPTION
Sending results to the collection server
https://github.com/mozilla/KitchenSinkServer running on 127.0.0.1:8093

All runTests is now sending callbacks after receiving all results (or
timeout)

Data format is defined in KitchenSinkServer
{
  test_result: // JSON.stringify({
    {api_name}: {
      "preparation": (-1/0/1), # -1: no preparation needed
                               #  0: not prepared (and it should)
                               #  1: prepared
      "tests": {
        {testName}: (0/1),   #  0: failed
                             #  1: passed
        ...
      },
      ("timeout": 1)           #  any test interrupted by setTimeout
    },
    ...
  }),
  device: // currently null, we might have some way to provide the model,
  phone: // uri identifying the app in collection server,
  app_version: // version of the kitchensink app,
  user_agent: // navigator.userAgent
}
- few test callbacks fixed
- wifi manage removed from manifest as it needs certified app
- settings is showing up as a dark modal
- switching certified from the settings page
- set the default setting state
